### PR TITLE
Edit status bar padding

### DIFF
--- a/resource-overlay/device/SystemUI/res/values/dimens.xml
+++ b/resource-overlay/device/SystemUI/res/values/dimens.xml
@@ -5,16 +5,13 @@
 -->
 <resources>
     <!-- the padding on the start of the statusbar -->
-    <dimen name="status_bar_padding_start">20.0dip</dimen>
+    <dimen name="status_bar_padding_start">14.0dip</dimen>
 
     <!-- the padding on the end of the statusbar -->
-    <dimen name="status_bar_padding_end">7.0dip</dimen>
+    <dimen name="status_bar_padding_end">3.0dip</dimen>
 
     <!-- the padding on the top of the statusbar (usually 0) -->
     <dimen name="status_bar_padding_top">20.0px</dimen>
-
-    <!-- Height of the status bar header bar when on Keyguard -->
-    <dimen name="status_bar_header_height_keyguard">@*android:dimen/status_bar_height</dimen>
 
     <!-- Margin on the left side of the carrier text on Keyguard -->
     <dimen name="keyguard_carrier_text_margin">16.0dip</dimen>


### PR DESCRIPTION
Edit the padding at the start and end of the status bar to reduce empty space, and align the lockscreen status bar with the home screen.